### PR TITLE
Run apt commands with noninteractive frontend

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,10 +13,11 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     # Prevents prompt during install
-    echo '* libraries/restart-without-asking boolean true' | debconf-set-selections
-    apt-get update
-    apt-get install -y parted build-essential bc curl fakeroot git kernel-wedge quilt ccache flex bison libssl-dev dh-exec \
-      crossbuild-essential-armhf crossbuild-essential-arm64 rsync libelf-dev cryptsetup vmdb2 dosfstools qemu-user-static \
+    DEBIAN_FRONTEND=noninteractive apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y parted build-essential bc \
+      curl fakeroot git kernel-wedge quilt ccache flex bison libssl-dev dh-exec \
+      crossbuild-essential-armhf crossbuild-essential-arm64 rsync libelf-dev \
+      cryptsetup vmdb2 dosfstools qemu-user-static \
       binfmt-support time
     echo "fs.inotify.max_user_watches=524288" > /etc/sysctl.d/50-inotify_user_watches.conf
     parted /dev/sda resizepart 1 100%


### PR DESCRIPTION
At least one package still wanted to prompt me during `vagrant up`. Setting `DEBIAN_FRONTEND=noninteractive` is commonly used in contexts like `docker`.